### PR TITLE
fix Lua errors for ScreenOptionsService

### DIFF
--- a/BGAnimations/ScreenOptionsService overlay/default.lua
+++ b/BGAnimations/ScreenOptionsService overlay/default.lua
@@ -17,7 +17,7 @@ for childscreen_name in THEME:GetMetric("ScreenOptionsService", "LineNames"):gma
 
 	-- We can prepend "Screen" to the beginning of each child screen's Name to transform
 	-- something like "InputOptions" into "ScreenInputOptions".
-	-- From there, we can see metric'c "ScreenInputOptions" has its own LineNames
+	-- From there, we can see metric's "ScreenInputOptions" has its own LineNames
 	-- and split those on commas to get OptionRows that would be available on the next screen.
 	--
 	-- This is is not a safe assumption in other themes (or even everyhere in SL), but I've configured

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -639,7 +639,7 @@ CustomTimingWindow=Timing Window
 MusicWheelSpeed=MusicWheel\nScroll Speed
 
 # Acknowledgments Menu
-StepMania Credits=♥  StepMania Credits
+StepManiaCredits=♥  StepMania Credits
 SimplyLoveCredits=♥  Simply Love Acknowledgments
 HereInTheDarkness=        here in the darkness
 
@@ -819,7 +819,7 @@ EasterEggs=Enable or disable some secret surprises a theme author may or may not
 AllowSongDeletion=Allow players to permanently delete songs from the computer by pressing Control + Backspace when browsing the MusicWheel.
 
 # Acknowledgments Menu
-StepMania Credits=Celebrate those who made StepMania possible.
+StepManiaCredits=Celebrate those who made StepMania possible.
 SimplyLoveCredits=Celebrate those who made this theme possible.
 HereInTheDarkness=that knows no end, the earth turns\nquiet like our hearts
 

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -233,6 +233,14 @@ SL_CustomPrefs.Get = function()
 		},
 
 		-- - - - - - - - - - - - - - - - - - - -
+		-- here in the darkness
+		HereInTheDarkness = {
+			Default = 0,
+			Choices = range(0, 23, 1),
+			Values  = range(0, 23, 1),
+		},
+
+		-- - - - - - - - - - - - - - - - - - - -
 		-- nice meme
 		-- 0 is off, 1 is visuals only, 2 is visuals and sound.
 		nice = {

--- a/metrics.ini
+++ b/metrics.ini
@@ -1080,11 +1080,12 @@ ShowCreditDisplay=false
 [ScreenOverscanConfig]
 PrevScreen="ScreenVisualOptions"
 NextScreen="ScreenVisualOptions"
+
 [ScreenAcknowledgmentsMenu]
 Fallback="ScreenOptionsServiceSub"
-LineNames="SimplyLoveCredits,StepMania Credits" .. ((ThemePrefs.Get("HereInTheDarkness") > 0 and ThemePrefs.Get("HereInTheDarkness") ~= 21) and ",HereInTheDarkness" or "")
+LineNames="SimplyLoveCredits,StepManiaCredits" .. ((ThemePrefs.Get("HereInTheDarkness") > 0 and ThemePrefs.Get("HereInTheDarkness") ~= 21) and ",HereInTheDarkness" or "")
 LineSimplyLoveCredits="gamecommand;screen,ScreenSLAcknowledgments;name,SimplyLoveCredits"
-LineStepMania Credits="gamecommand;screen,ScreenCredits;name,StepMania Credits"
+LineStepManiaCredits="gamecommand;screen,ScreenCredits;name,StepManiaCredits"
 LineHereInTheDarkness="gamecommand;screen,ScreenHereInTheDarkness;name,HereInTheDarkness"
 
 # StepMania 5 Credits as provided by the _fallback theme
@@ -2250,6 +2251,3 @@ ShowCoinData=true
 UnlockAuthString=""
 CustomLoadFunction=LoadProfileCustom
 CustomSaveFunction=SaveProfileCustom
-
-
-


### PR DESCRIPTION
It looks like ScreenOptionsServer was missing a necessary `ThemePrefs` configuration and a few strings, probably from a merge.

The fixes here allow the main operator menu screen to display its side pane and allows changes made in ScreenThemeOptions to save to ThemePrefs.ini again.