### PR TITLE
fixes for Eval's Test Input pane

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane5/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane5/default.lua
@@ -10,19 +10,14 @@ if not (game=="dance" or game=="pump" or game=="techno") then return end
 
 -- -----------------------------------------------------------------------
 
-local player = unpack(...)
+local player, controller = unpack(...)
 
 local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local pane = Def.ActorFrame{
-	Name="Pane5",
 	InitCommand=function(self)
 		if style == "OnePlayerTwoSides" then
-			if IsUsingWideScreen() then
-				self:x( -107 )
-			else
-				self:x( -_screen.w/6 )
-			end
+			self:x(controller==PLAYER_1 and 50 or -260)
 		end
 	end,
 	-- ExpandForDoubleCommand() does not do anything here, but we check for its presence in


### PR DESCRIPTION
[Upstream pull request #334](https://github.com/Simply-Love/Simply-Love-SM5/pull/334) pointed out that the Test Input pane in
ScreenEvaluation was positioned incorrectly when playing double as
PLAYER_2.

I went to investigate and found that the entire pane was throwing errors
and failing to load in this branch.  I fixed that by removing the
`Name="Pane5"` attribute, since the InputHandler [looks for unnamed
ActorFrames](https://github.com/CrashCringle12/Simply-Love-SM5/blob/062a6adabb136956d804fe5cd3afded41da4ca72/BGAnimations/ScreenEvaluation%20common/InputHandler.lua#L155) when cycling through panes. Having a name was preventing
the InputHandler from finding this particular pane.

With that in place, the pad graphics were indeed offset too much, so I
brought over Valentina16's changes.